### PR TITLE
Add timeofday command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -133,3 +133,12 @@ irc:register_bot_command("say", {
 	end
 })
 
+irc:register_bot_command("timeofday", {
+	description = "Tell the in-game time of day",
+	func = function(user, args)
+		local timeofday = minetest.get_timeofday()
+		local hours, minutes = math.modf(timeofday * 24)
+		minutes = math.floor(minutes * 60)
+		return true, "It's " .. hours .. " h " .. minutes .. " min."
+	end
+})


### PR DESCRIPTION
Very often a player which is on IRC wants to know what time is it in-game. So, I've added a simple command : timeofday.