### PR TITLE
Replace deprecated use of colon notation when calling irc methods 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,7 +11,7 @@ minetest.chat_send_player = function(name, message)
 	return old_chat_send_player(name, message)
 end
 
-irc:register_hook("NickChange", function(user, newNick)
+irc.register_hook("NickChange", function(user, newNick)
 	for nick, player in pairs(irc_users) do
 		if nick == user.nick then
 			irc_users[newNick] = irc_users[user.nick]
@@ -20,19 +20,19 @@ irc:register_hook("NickChange", function(user, newNick)
 	end
 end)
 
-irc:register_hook("OnPart", function(user, channel, reason)
+irc.register_hook("OnPart", function(user, channel, reason)
 	irc_users[user.nick] = nil
 end)
 
-irc:register_hook("OnKick", function(user, channel, target, reason)
+irc.register_hook("OnKick", function(user, channel, target, reason)
 	irc_users[target] = nil
 end)
 
-irc:register_hook("OnQuit", function(user, reason)
+irc.register_hook("OnQuit", function(user, reason)
 	irc_users[user.nick] = nil
 end)
 
-irc:register_bot_command("login", {
+irc.register_bot_command("login", {
 	params = "<username> <password>",
 	description = "Login as a user to run commands",
 	func = function(user, args)
@@ -74,7 +74,7 @@ irc:register_bot_command("login", {
 	end
 })
 
-irc:register_bot_command("logout", {
+irc.register_bot_command("logout", {
 	description = "Logout",
 	func = function (user, args)
 		if irc_users[user.nick] then
@@ -88,7 +88,7 @@ irc:register_bot_command("logout", {
 	end,
 })
 
-irc:register_bot_command("cmd", {
+irc.register_bot_command("cmd", {
 	params = "<command>",
 	description = "Run a command on the server",
 	func = function (user, args)
@@ -115,7 +115,7 @@ irc:register_bot_command("cmd", {
 	end
 })
 
-irc:register_bot_command("say", {
+irc.register_bot_command("say", {
 	params = "message",
 	description = "Say something",
 	func = function (user, args)


### PR DESCRIPTION
Replace deprecated use of colon notation when calling methods `register_hook` and `register_bot_command`

This change removes 8 warnings from debug.txt every time server starts.
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_hook` at @/minetest/mods/irc_commands/init.lua:14
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_hook` at @/minetest/mods/irc_commands/init.lua:23
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_hook` at @/minetest/mods/irc_commands/init.lua:27
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_hook` at @/minetest/mods/irc_commands/init.lua:31
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_bot_command` at @/minetest/mods/irc_commands/init.lua:35
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_bot_command` at @/minetest/mods/irc_commands/init.lua:77
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_bot_command` at @/minetest/mods/irc_commands/init.lua:91
2018-06-12 11:17:25: WARNING[Main]: Deprecated use of colon notation when calling method `register_bot_command` at @/minetest/mods/irc_commands/init.lua:118